### PR TITLE
KAN-669 feat: 식품 조회 페이지에 재고 등록 api 연동 추가

### DIFF
--- a/src/pages/customer/ProductEco.jsx
+++ b/src/pages/customer/ProductEco.jsx
@@ -1,4 +1,5 @@
 import { fetchEcoProductItems, registerTimesale, registerAdvertisement } from '../../apis/apisProducts';
+import { registerProductInventory } from '../../apis/apisInventory'; 
 import { useEffect, useRef, useState} from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Flex, Space, Table, Tag, Button, Input, message } from 'antd'
@@ -42,8 +43,6 @@ const ProductEco = () => {
     },
   });
 
-  // ----------------------------------------------------------------------------------
-
   useEffect(() => {
     fetchProducts();
     
@@ -77,8 +76,8 @@ const ProductEco = () => {
         }
       });
 
-      console.log('Sending params:', params);
-      console.log('Fetching with params:', params);
+      // console.log('Sending params:', params);
+      // console.log('Fetching with params:', params);
 
       const response = await fetchEcoProductItems(params);
       
@@ -142,6 +141,7 @@ const ProductEco = () => {
     fetchProducts();
   };
 
+  // 상단 노출 신청
   const onHandlePromotionApply = async () => {
     if (selectedRowKeys.length !== 1) {
       message.warning('상단 노출을 신청할 상품을 하나만 선택해주세요.');
@@ -239,6 +239,66 @@ const ProductEco = () => {
     }
   };
 
+  // 재고 등록 버튼
+  const onHandleInventoryRegister = (event, record) => {
+    event.stopPropagation();  // 이벤트 전파 중단
+    Swal.fire({
+      title: '재고 등록',
+      html:
+      '<div class="swal2-input-group">' +
+      '<label for="swal-input1" class="swal2-input-label">입고날짜:</label>' +
+      '<input id="swal-input1" class="swal2-input" type="date">' +
+      '</div>' +
+      '<div class="swal2-input-group">' +
+      '<label for="swal-input2" class="swal2-input-label">재고수량:</label>' +
+      '<input id="swal-input2" class="swal2-input" type="number">' +
+      '</div>' +
+      '<div class="swal2-input-group">' +
+      '<label for="swal-input3" class="swal2-input-label">소비기한:</label>' +
+      '<input id="swal-input3" class="swal2-input" type="date">' +
+      '</div>',
+      focusConfirm: false,
+      preConfirm: () => {
+        return {
+          warehouseDate: document.getElementById('swal-input1').value,
+          quantity: document.getElementById('swal-input2').value,
+          expirationDate: document.getElementById('swal-input3').value
+        }
+      }
+    }).then((result) => {
+      if (result.isConfirmed) {
+        const { warehouseDate, quantity, expirationDate } = result.value;
+        if (!warehouseDate || !quantity || !expirationDate) {
+          Swal.fire('오류', '모든 필드를 입력해주세요.', 'error');
+          return;
+        }
+        onHandleInventoryCreate(record.productId, warehouseDate, parseInt(quantity), expirationDate);
+      }
+    });
+  };
+
+  // 재고 등록
+  const onHandleInventoryCreate = async (productId, warehouseDate, quantity, expirationDate) => {
+    try {
+      const registerData = {
+        productId,
+        warehouseDate,
+        quantity,
+        expirationDate
+      };
+      const response = await registerProductInventory(registerData);
+      if (response && response.successCode === SuccessCode.INSERT_SUCCESS) {
+        message.success('재고가 성공적으로 등록되었습니다.');
+        //fetchInventorySummaryData(); // 재고 요약 데이터 새로고침
+      } else {
+        //message.error('재고 등록에 실패했습니다.');
+      }
+    } catch (error) {
+      console.error('재고 등록 오류:', error);
+      message.error('재고 등록에 실패했습니다.');
+    }
+  };
+
   const getColumnSearchProps = (dataIndex) => ({
     filterDropdown: ({ setSelectedKeys, selectedKeys, confirm, clearFilters, close }) => (
       <div style={{ padding: 8 }}>
@@ -323,8 +383,11 @@ const ProductEco = () => {
 
   const onRow = (record) => {
     return {
-      onClick: () => {
-        navigate(`/product/eco/${record.productId}`)
+      onClick: (event) => {
+        // 재고 등록 버튼 클릭 시 상세 페이지로 이동하지 않음
+        if (event.target.tagName != 'BUTTON') {
+          navigate(`/product/eco/${record.productId}`)
+        }
       }
     };
   };
@@ -456,6 +519,7 @@ const ProductEco = () => {
       title: '식품ID', 
       dataIndex: 'productId', 
       key: 'productId',
+      width: '10%',
       filteredValue: joinForm.productId ? [joinForm.productId] : null,
       ...getColumnSearchProps('productId'),
     },
@@ -531,6 +595,13 @@ const ProductEco = () => {
         </Tag>
       ),
     },
+    {
+      title: '재고 등록',
+      key: 'register',
+      render: (_, record) => (
+        <Button onClick={(event) => onHandleInventoryRegister(event, record)}>재고 등록</Button>
+      ),
+    }
   ];
 
   const getTagColor = (status) => {


### PR DESCRIPTION
[![KAN-113](https://badgen.net/badge/JIRA/KAN-113/blue?icon=jira)](https://jira.company.com/browse/KAN-113) [![PR-43](https://badgen.net/badge/Preview/PR-43/blue)](https://pr-43.company.com) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=HS-Continuity&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--

PR 제목 예시

title : KAN-000 feat: 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- 일반 식품 조회 페이지에 재고 등록 api 연동
- 친환경 식품 조회 페이지에 재고 등록 api 연동

## #️⃣관련 이슈

- KAN-669

## 📝세부 작업 내용

- [x] 일반 식품 상세 페이지 table에 각 행마다 재고 등록 버튼 추가 (api 연동)
- [x] 친환경 식품 상세 페이지 table에 각 행마다 재고 등록 버튼 추가 (api 연동)

## 💬참고 사항

[KAN-113]: https://hysoung-kosa-team4.atlassian.net/browse/KAN-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ