### PR TITLE
Kan-113  refactor: 식품관리 식품 삭제 api 연동 수정

### DIFF
--- a/src/pages/customer/ProductEcoDetail.jsx
+++ b/src/pages/customer/ProductEcoDetail.jsx
@@ -2,8 +2,8 @@ import { deleteProduct, fetchProductDetail, updateProduct, fetchProductCertifica
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Flex, Form, Input, InputNumber, Switch, Card, Row, Col, Typography, Button, Space, message, Upload } from 'antd';
-import { LeftOutlined } from '@ant-design/icons';
-import { FileOutlined } from '@ant-design/icons';
+import { LeftOutlined, FileOutlined } from '@ant-design/icons';
+import Swal from 'sweetalert2';
 
 const { Title } = Typography;
 
@@ -86,15 +86,37 @@ const ProductEcoDetail = () => {
     }
   };
 
-  const onHandleDelete = async () => {
-    try {
-      await deleteProduct(productId);
-      message.success('상품이 성공적으로 삭제되었습니다.');
-      navigate(-1);  // 상품 목록 페이지로 이동
-    } catch (error) {
-      console.error('Error deleting product: ', error);
-      message.error('상품 삭제에 실패했습니다.');
-    }
+  const onHandleDelete = () => {
+    Swal.fire({
+      title: '정말 삭제하시겠습니까?',
+      text: "이 작업은 되돌릴 수 없습니다!",
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: '#d33',
+      cancelButtonColor: '#3085d6',
+      confirmButtonText: '삭제하기',
+      cancelButtonText: '취소'
+    }).then((result) => {
+      if (result.isConfirmed) {
+        deleteProduct(productId)
+          .then(() => {
+            Swal.fire(
+              '삭제완료!',
+              '상품이 성공적으로 삭제되었습니다.',
+              'success'
+            );
+            navigate(-1);  // 상품 목록 페이지로 이동
+          })
+          .catch((error) => {
+            console.error('Error deleting product: ', error);
+            Swal.fire(
+              '삭제 실패',
+              '상품 삭제에 실패했습니다.',
+              'error'
+            );
+          });
+      }
+    });
   };
 
   const onHandleDownload = (file) => {
@@ -116,7 +138,6 @@ const ProductEcoDetail = () => {
         <LeftOutlined onClick={onHandleBackClick} />
         <Title level={3} style={{ marginBottom: '16px' }}>친환경 상품 상세 정보</Title>
       </Flex>
-      {/* <Title level={3} style={{ marginBottom: '16px' }}>친환경 상품 상세 정보</Title> */}
       <Form form={form} layout="vertical">
         <Row gutter={16}>
           <Col span={24}>
@@ -155,9 +176,6 @@ const ProductEcoDetail = () => {
                   <Form.Item name="baseDiscountRate" label="기본 할인율 (%)" style={formItemStyle}>
                     <InputNumber style={{ ...inputStyle, width: '100%' }} />
                   </Form.Item>
-                  {/* <Form.Item name="regularDiscountRate" label="정기 배송 할인율 (%)" style={formItemStyle}>
-                    <InputNumber style={{ ...inputStyle, width: '100%' }} />
-                  </Form.Item> */}
                   <Form.Item
                     noStyle
                     shouldUpdate={(prevValues, currentValues) => prevValues.isRegularSale !== currentValues.isRegularSale}

--- a/src/pages/customer/ProductGeneralDetail.jsx
+++ b/src/pages/customer/ProductGeneralDetail.jsx
@@ -4,6 +4,7 @@ import { LeftOutlined } from '@ant-design/icons';
 import { useParams } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 import { Flex, Form, Input, InputNumber, Switch, Card, Row, Col, Typography, Button, Space, message } from 'antd';
+import Swal from 'sweetalert2';
 
 const { Title } = Typography;
 
@@ -77,15 +78,38 @@ const ProductGeneralDetail = () => {
     }
   };
 
-  const onHandleDelete = async () => {
-    try {
-      await deleteProduct(productId);
-      message.success('상품이 성공적으로 삭제되었습니다.');
-      navigate(-1);  // 상품 목록 페이지로 이동
-    } catch (error) {
-      console.error('Error deleting product: ', error);
-      message.error('상품 삭제에 실패했습니다.');
-    }
+  const onHandleDelete = () => {
+    Swal.fire({
+      title: '정말 삭제하시겠습니까?',
+      text: "이 작업은 되돌릴 수 없습니다!",
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: '#d33',
+      cancelButtonColor: '#3085d6',
+      confirmButtonText: '삭제하기',
+      cancelButtonText: '취소'
+    }).then((result) => {
+      if (result.isConfirmed) {
+        console.log('삭제할 상품아이디: ', productId)
+        deleteProduct(productId)
+          .then(() => {
+            Swal.fire(
+              '삭제완료!',
+              '상품이 성공적으로 삭제되었습니다.',
+              'success'
+            );
+            navigate(-1);  // 상품 목록 페이지로 이동
+          })
+          .catch((error) => {
+            console.error('Error deleting product: ', error);
+            Swal.fire(
+              '삭제 실패',
+              '상품 삭제에 실패했습니다.',
+              'error'
+            );
+          });
+      }
+    });
   };
 
   const onHandleBackClick = () => {
@@ -97,13 +121,6 @@ const ProductGeneralDetail = () => {
       <Flex gap="small" justify="flex-start" align="center" style={{ width: 'fit-content' }}>
         <LeftOutlined onClick={onHandleBackClick}/>
         <Title level={3}>식품 등록</Title>
-        {/* <Breadcrumb style={{ marginBottom: '20px' }}
-          items={[
-            { title: 'Main' },
-            { title: selectedFoodType === '일반식품' ? '일반식품관리' : '친환경식품관리' },
-            { title: `${selectedFoodType} 등록` },
-          ]}
-        /> */}
       </Flex>
       <Form form={form} layout="vertical">
         <Row gutter={16}>
@@ -143,9 +160,6 @@ const ProductGeneralDetail = () => {
                   <Form.Item name="baseDiscountRate" label="기본 할인율 (%)" style={formItemStyle}>
                     <InputNumber style={{ ...inputStyle, width: '100%' }} />
                   </Form.Item>
-                  {/* <Form.Item name="regularDiscountRate" label="정기 배송 할인율 (%)" style={formItemStyle}>
-                    <InputNumber style={{ ...inputStyle, width: '100%' }} />
-                  </Form.Item> */}
                   <Form.Item
                     noStyle
                     shouldUpdate={(prevValues, currentValues) => prevValues.isRegularSale !== currentValues.isRegularSale}


### PR DESCRIPTION
[![KAN-113](https://badgen.net/badge/JIRA/KAN-113/blue?icon=jira)](https://jira.company.com/browse/KAN-113) [![PR-60](https://badgen.net/badge/Preview/PR-60/blue)](https://pr-60.company.com) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=HS-Continuity&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--

PR 제목 예시

title : KAN-000 feat: 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- 식품 삭제 버튼 클릭 시 모달창 한 번 더 거치기

## #️⃣관련 이슈

- KAN-708

## 📝세부 작업 내용

- [x] 일반 식품 삭제 api 연동 수정
- [x] 친환경 식품 삭제 api 연동 수정

## 💬참고 사항

[KAN-113]: https://hysoung-kosa-team4.atlassian.net/browse/KAN-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ